### PR TITLE
Initialize ATHENAS project with RAG prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Projeto_ATHENAS
+# Projeto ATHENAS
+
+Protótipo inicial da plataforma de **Inteligência de Acesso ao Conhecimento**
+descrita no documento PDF deste repositório.
+
+Este repositório contém uma implementação mínima do fluxo RAG (Retrieval-Augmented Generation)
+utilizado pela ATHENAS. O objetivo é servir como ponto de partida para evolução do MVP.
+
+## Estrutura
+
+- `athenas/core.py` – pipeline básico de RAG com componentes substituíveis.
+- `athenas/cli.py` – interface de linha de comando de demonstração.
+
+## Como executar
+
+```bash
+python -m athenas.cli "Qual a proposta da ATHENAS?"
+```
+
+O comando utiliza documentos fictícios apenas para ilustrar o fluxo.

--- a/athenas/__init__.py
+++ b/athenas/__init__.py
@@ -1,0 +1,1 @@
+"""Pacote principal do projeto ATHENAS."""

--- a/athenas/cli.py
+++ b/athenas/cli.py
@@ -1,0 +1,30 @@
+"""Interface de linha de comando para o protótipo da ATHENAS."""
+
+import argparse
+
+from .core import AthenasRAG
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Protótipo inicial da ATHENAS")
+    parser.add_argument(
+        "pergunta",
+        nargs="?",
+        default="Qual o objetivo do projeto?",
+        help="Pergunta a ser respondida.",
+    )
+    args = parser.parse_args()
+
+    # Documentos de exemplo. Em versões futuras serão substituídos por dados corporativos.
+    documentos = [
+        "A ATHENAS é um assistente IA conversacional que unifica o conhecimento interno.",
+        "O objetivo inicial é reduzir o tempo médio gasto na busca por informações.",
+    ]
+
+    rag = AthenasRAG()
+    resposta = rag.answer(args.pergunta, documentos)
+    print(resposta)
+
+
+if __name__ == "__main__":
+    main()

--- a/athenas/core.py
+++ b/athenas/core.py
@@ -1,0 +1,46 @@
+"""Prototipo inicial do mecanismo RAG da ATHENAS."""
+
+from typing import Iterable, List
+
+
+class AthenasRAG:
+    """Estrutura simples de Retrieval-Augmented Generation para o MVP da ATHENAS.
+
+    O pipeline segue três etapas: geração de embeddings, busca e síntese da resposta.
+    As implementações aqui são placeholders que deverão ser substituídas por
+    modelos reais e integrações conforme evolução do projeto.
+    """
+
+    def __init__(self, embedder=None, retriever=None, generator=None):
+        self.embedder = embedder or self._default_embedder
+        self.retriever = retriever or self._default_retriever
+        self.generator = generator or self._default_generator
+
+    def _default_embedder(self, text: str) -> List[int]:
+        """Gera um vetor numérico simples a partir das palavras.
+
+        Esta função estática serve apenas para permitir experimentos iniciais
+        sem dependências externas.
+        """
+        return [len(word) for word in text.split()]
+
+    def _default_retriever(self, query_embedding: List[int],
+                           documents: Iterable[str]) -> Iterable[str]:
+        """Retorna todos os documentos sem qualquer ordenação.
+
+        Substitua por uma busca vetorial de verdade em versões futuras.
+        """
+        return documents
+
+    def _default_generator(self, query: str, context: str) -> str:
+        """Gera uma resposta trivial baseada no contexto.
+
+        Em produção esta etapa chamará um LLM (por exemplo GPT-4).
+        """
+        return f"Pergunta: {query}\nContexto utilizado: {context}"
+
+    def answer(self, query: str, documents: List[str]) -> str:
+        """Executa o pipeline completo de pergunta e resposta."""
+        docs = list(documents)
+        relevant = next(iter(self.retriever(self.embedder(query), docs)), "")
+        return self.generator(query, relevant)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Dependências futuras do projeto ATHENAS
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- scaffold ATHENAS package with placeholder RAG pipeline
- add CLI demo for answering questions over sample documents
- document project setup and basic usage

## Testing
- `python -m athenas.cli "O que é a ATHENAS?"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae571c70ac8327bab91f60db19c674