### PR TITLE
feat: add dockerized backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,21 @@ python -m athenas.cli "Qual a proposta da ATHENAS?"
 ```
 
 O comando utiliza documentos fictícios apenas para ilustrar o fluxo.
+
+## Execução com Docker
+
+Uma API simples de demonstração está disponível via Docker. Para subir o
+ambiente completo (backend FastAPI e banco vetorial ChromaDB), utilize:
+
+```bash
+docker-compose up --build
+```
+
+Após a inicialização, o endpoint estará disponível em
+`http://localhost:8000/answer`. Exemplo de requisição:
+
+```
+http://localhost:8000/answer?pergunta=Qual%20o%20objetivo%20do%20projeto?
+```
+
+O serviço `vector-db` expõe a porta `8001` apenas para fins de demonstração.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from athenas.core import AthenasRAG
+
+app = FastAPI(title="ATHENAS MVP")
+rag = AthenasRAG()
+
+# Documentos de exemplo para demonstração
+documents = [
+    "A ATHENAS é um assistente IA conversacional que unifica o conhecimento interno.",
+    "O objetivo inicial é reduzir o tempo médio gasto na busca por informações.",
+]
+
+@app.get("/answer")
+async def answer(pergunta: str):
+    """Endpoint simples que utiliza o pipeline RAG."""
+    resposta = rag.answer(pergunta, documents)
+    return {"pergunta": pergunta, "resposta": resposta}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+openai>=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    depends_on:
+      - vector-db
+  vector-db:
+    image: chromadb/chroma
+    ports:
+      - "8001:8001"


### PR DESCRIPTION
## Summary
- add FastAPI backend exposing RAG endpoint
- provide Dockerfile and docker-compose stack with ChromaDB service
- document Docker usage in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae5924336483278e5fa815a7642c67