### PR TITLE
Integrate OpenAI embedding and ChromaDB retrieval

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/athenas/cli.py
+++ b/athenas/cli.py
@@ -15,14 +15,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    # Documentos de exemplo. Em versões futuras serão substituídos por dados corporativos.
-    documentos = [
-        "A ATHENAS é um assistente IA conversacional que unifica o conhecimento interno.",
-        "O objetivo inicial é reduzir o tempo médio gasto na busca por informações.",
-    ]
-
     rag = AthenasRAG()
-    resposta = rag.answer(args.pergunta, documentos)
+    resposta = rag.answer(args.pergunta)
     print(resposta)
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,14 +4,8 @@ from athenas.core import AthenasRAG
 app = FastAPI(title="ATHENAS MVP")
 rag = AthenasRAG()
 
-# Documentos de exemplo para demonstração
-documents = [
-    "A ATHENAS é um assistente IA conversacional que unifica o conhecimento interno.",
-    "O objetivo inicial é reduzir o tempo médio gasto na busca por informações.",
-]
-
 @app.get("/answer")
 async def answer(pergunta: str):
     """Endpoint simples que utiliza o pipeline RAG."""
-    resposta = rag.answer(pergunta, documents)
+    resposta = rag.answer(pergunta)
     return {"pergunta": pergunta, "resposta": resposta}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # Dependências futuras do projeto ATHENAS
 openai>=1.0.0
+python-dotenv>=1.0.0
+chromadb>=0.5.0


### PR DESCRIPTION
## Summary
- replace placeholder embedding and retrieval with OpenAI embeddings and ChromaDB vector search
- expose simplified CLI and FastAPI endpoint using new retrieval flow
- add dotenv, chromadb and example environment file for API configuration

## Testing
- `python - <<'PY'
import importlib
for mod in ('openai', 'dotenv', 'chromadb'):
    importlib.import_module(mod)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5b2856a8832782790f3abdddac72