### PR TITLE
Add Streamlit chat frontend

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+import streamlit as st
+import requests
+
+st.set_page_config(page_title="Assistente de Conhecimento ATHENAS")
+
+st.title("Assistente de Conhecimento ATHENAS")
+
+pergunta = st.text_input("Digite sua pergunta:")
+
+resposta_area = st.empty()
+
+if st.button("Enviar"):
+    if pergunta:
+        try:
+            resp = requests.get("http://localhost:8000/answer", params={"pergunta": pergunta})
+            if resp.ok:
+                data = resp.json()
+                resposta_area.write(data.get("resposta", ""))
+            else:
+                resposta_area.error(f"Erro {resp.status_code}")
+        except Exception as e:
+            resposta_area.error(f"Erro ao conectar ao backend: {e}")
+    else:
+        resposta_area.warning("Digite uma pergunta antes de enviar.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ openai>=1.0.0
 python-dotenv>=1.0.0
 chromadb>=0.5.0
 langchain>=0.1.0
+
+streamlit>=1.30.0
+requests>=2.0.0


### PR DESCRIPTION
## Summary
- add Streamlit-based web interface for ATHENAS
- update requirements with Streamlit and requests

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0ff7412b083279111559998b624ac