### PR TITLE
Expose answer sources in API and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,11 @@ if st.button("Enviar"):
             if resp.ok:
                 data = resp.json()
                 resposta_area.write(data.get("resposta", ""))
+                fontes = data.get("fontes", [])
+                if fontes:
+                    with st.expander("Fontes utilizadas"):
+                        for fonte in fontes:
+                            st.write(fonte)
             else:
                 resposta_area.error(f"Erro {resp.status_code}")
         except Exception as e:

--- a/athenas/cli.py
+++ b/athenas/cli.py
@@ -16,8 +16,8 @@ def main() -> None:
     args = parser.parse_args()
 
     rag = AthenasRAG()
-    resposta = rag.answer(args.pergunta)
-    print({"pergunta": args.pergunta, "resposta": resposta})
+    resposta, fontes = rag.answer(args.pergunta)
+    print({"pergunta": args.pergunta, "resposta": resposta, "fontes": fontes})
 
 
 if __name__ == "__main__":

--- a/athenas/core.py
+++ b/athenas/core.py
@@ -1,6 +1,6 @@
 """Prototipo inicial do mecanismo RAG da ATHENAS."""
 
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 
 class AthenasRAG:
@@ -79,7 +79,9 @@ class AthenasRAG:
 
         return completion.choices[0].message.content.strip()
 
-    def answer(self, query: str) -> str:
-        """Executa o pipeline completo de pergunta e resposta."""
-        relevant = next(iter(self.retriever(query)), "")
-        return self.generator(query, relevant)
+    def answer(self, query: str) -> Tuple[str, List[str]]:
+        """Executa o pipeline de pergunta e resposta retornando também as fontes."""
+        relevant_docs = list(self.retriever(query))
+        context = "\n\n".join(relevant_docs)
+        resposta = self.generator(query, context)
+        return resposta, relevant_docs

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,5 +8,5 @@ app = FastAPI(title="ATHENAS MVP")
 async def answer(pergunta: str):
     """Endpoint simples que utiliza o pipeline RAG completo."""
     rag = AthenasRAG()
-    resposta = rag.answer(pergunta)
-    return {"pergunta": pergunta, "resposta": resposta}
+    resposta, fontes = rag.answer(pergunta)
+    return {"pergunta": pergunta, "resposta": resposta, "fontes": fontes}


### PR DESCRIPTION
## Summary
- Return retrieved document snippets alongside generated answers
- Surface answer sources in backend and Streamlit UI
- Update CLI to display sources

## Testing
- `pytest`
- `python -m py_compile athenas/core.py athenas/cli.py backend/main.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b101a91bb88327a57ffde51eb88ae3