### PR TITLE
feat: support multiple formats and anonymization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ openai>=1.0.0
 python-dotenv>=1.0.0
 chromadb>=0.5.0
 langchain>=0.1.0
+langchain-community>=0.0.10
 
 streamlit>=1.30.0
 requests>=2.0.0
+presidio-analyzer>=2.2.30
+presidio-anonymizer>=2.2.30


### PR DESCRIPTION
## Summary
- add multi-format document loading using LangChain loaders
- anonymize sensitive data with Microsoft Presidio
- include Presidio and langchain-community dependencies

## Testing
- `pip install -r requirements.txt`
- `python ingest.py` *(fails: openai.AuthenticationError: Incorrect API key provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b102716cbc8327a308bf181b9887e8