### PR TITLE
feat: add conversation history

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,25 +5,36 @@ st.set_page_config(page_title="Assistente de Conhecimento ATHENAS")
 
 st.title("Assistente de Conhecimento ATHENAS")
 
-pergunta = st.text_input("Digite sua pergunta:")
+if "historico" not in st.session_state:
+    st.session_state["historico"] = []
 
-resposta_area = st.empty()
+for mensagem in st.session_state["historico"]:
+    st.markdown(f"**Você:** {mensagem['pergunta']}")
+    st.markdown(f"**ATHENAS:** {mensagem['resposta']}")
+    fontes_previas = mensagem.get("fontes", [])
+    if fontes_previas:
+        with st.expander("Fontes utilizadas"):
+            for fonte in fontes_previas:
+                st.write(fonte)
+
+pergunta = st.text_input("Digite sua pergunta:", key="pergunta_input")
 
 if st.button("Enviar"):
+    pergunta = st.session_state.get("pergunta_input", "")
     if pergunta:
         try:
             resp = requests.get("http://localhost:8000/answer", params={"pergunta": pergunta})
             if resp.ok:
                 data = resp.json()
-                resposta_area.write(data.get("resposta", ""))
+                resposta = data.get("resposta", "")
                 fontes = data.get("fontes", [])
-                if fontes:
-                    with st.expander("Fontes utilizadas"):
-                        for fonte in fontes:
-                            st.write(fonte)
+                st.session_state["historico"].append(
+                    {"pergunta": pergunta, "resposta": resposta, "fontes": fontes}
+                )
+                st.session_state["pergunta_input"] = ""
             else:
-                resposta_area.error(f"Erro {resp.status_code}")
+                st.error(f"Erro {resp.status_code}")
         except Exception as e:
-            resposta_area.error(f"Erro ao conectar ao backend: {e}")
+            st.error(f"Erro ao conectar ao backend: {e}")
     else:
-        resposta_area.warning("Digite uma pergunta antes de enviar.")
+        st.warning("Digite uma pergunta antes de enviar.")


### PR DESCRIPTION
## Summary
- add chat history using Streamlit session state for questions, answers, and sources

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1a464e6708327824cbe1ccf6c7c50