### PR TITLE
Expose source filenames for retrieved chunks

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,10 @@ for i, mensagem in enumerate(st.session_state["historico"]):
     if fontes_previas:
         with st.expander("Fontes utilizadas"):
             for fonte in fontes_previas:
-                st.write(fonte)
+                origem = fonte.get("fonte", "")
+                texto = fonte.get("texto", "")
+                st.markdown(f"**Fonte:** {origem}")
+                st.write(texto)
 
 pergunta = st.text_input("Digite sua pergunta:", key="pergunta_input")
 


### PR DESCRIPTION
## Summary
- return ChromaDB document source metadata alongside chunk text
- show filename origins for retrieved chunks in Streamlit client

## Testing
- `pytest`
- `python -m athenas.cli "Qual a proposta da ATHENAS?"` *(fails: Could not connect to a Chroma server)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad5cb5408327a6612bfbccfb89b3