### PR TITLE
Add basic logging and token tracking

### DIFF
--- a/athenas/cli.py
+++ b/athenas/cli.py
@@ -16,8 +16,13 @@ def main() -> None:
     args = parser.parse_args()
 
     rag = AthenasRAG()
-    resposta, fontes = rag.answer(args.pergunta)
-    print({"pergunta": args.pergunta, "resposta": resposta, "fontes": fontes})
+    resposta, fontes, tokens = rag.answer(args.pergunta)
+    print({
+        "pergunta": args.pergunta,
+        "resposta": resposta,
+        "fontes": fontes,
+        "tokens": tokens,
+    })
 
 
 if __name__ == "__main__":

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,11 @@
+import logging
+from time import perf_counter
+
 from fastapi import FastAPI
 from athenas.core import AthenasRAG
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="ATHENAS MVP")
 
@@ -7,6 +13,23 @@ app = FastAPI(title="ATHENAS MVP")
 @app.get("/answer")
 async def answer(pergunta: str):
     """Endpoint simples que utiliza o pipeline RAG completo."""
-    rag = AthenasRAG()
-    resposta, fontes = rag.answer(pergunta)
-    return {"pergunta": pergunta, "resposta": resposta, "fontes": fontes}
+    start_time = perf_counter()
+    logger.info("Pergunta recebida: %s", pergunta)
+    try:
+        rag = AthenasRAG()
+        resposta, fontes, tokens = rag.answer(pergunta)
+        elapsed = perf_counter() - start_time
+        logger.info("Tempo de resposta: %.2fs", elapsed)
+        logger.info("Tokens usados: %s", tokens)
+        return {
+            "pergunta": pergunta,
+            "resposta": resposta,
+            "fontes": fontes,
+            "tokens": tokens,
+            "tempo_resposta": elapsed,
+        }
+    except Exception as exc:
+        elapsed = perf_counter() - start_time
+        logger.exception("Erro ao processar pergunta: %s", exc)
+        logger.info("Tempo até erro: %.2fs", elapsed)
+        raise

--- a/evaluate.py
+++ b/evaluate.py
@@ -16,7 +16,7 @@ def evaluate(dataset_path: str = "golden_dataset.json", threshold: float = 0.6) 
         resposta_ideal = item["resposta_ideal"]
 
         try:
-            resposta_obtida, _ = rag.answer(pergunta)
+            resposta_obtida, _, _ = rag.answer(pergunta)
         except Exception as exc:
             resposta_obtida = f"Erro: {exc}"
 


### PR DESCRIPTION
## Summary
- instrument FastAPI endpoint with Python logging to record question, response time, token usage and errors
- expose token consumption in AthenasRAG pipeline and propagate to CLI and evaluation utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1af5186f48327b3455ea7e7e41663