### PR TITLE
feat: add in-memory cache for repeated questions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import logging
-from time import perf_counter
+from time import perf_counter, time
+from typing import Any, Dict, Tuple
 
 from fastapi import FastAPI
 from athenas.core import AthenasRAG
@@ -10,17 +11,35 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="ATHENAS MVP")
 
 
+CACHE_TTL = 300  # segundos
+_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
+
 @app.get("/answer")
 async def answer(pergunta: str):
-    """Endpoint simples que utiliza o pipeline RAG completo."""
+    """Endpoint simples que utiliza o pipeline RAG completo.
+
+    Utiliza um cache em memória para evitar chamadas repetidas à API da OpenAI.
+    """
     start_time = perf_counter()
     logger.info("Pergunta recebida: %s", pergunta)
+
+    now = time()
+    cached = _cache.get(pergunta)
+    if cached and now - cached[0] < CACHE_TTL:
+        logger.info("Resposta retornada do cache")
+        elapsed = perf_counter() - start_time
+        return {"pergunta": pergunta, **cached[1], "tempo_resposta": elapsed}
+    elif cached:
+        del _cache[pergunta]
+
     try:
         rag = AthenasRAG()
         resposta, fontes, tokens = rag.answer(pergunta)
         elapsed = perf_counter() - start_time
         logger.info("Tempo de resposta: %.2fs", elapsed)
         logger.info("Tokens usados: %s", tokens)
+        _cache[pergunta] = (now, {"resposta": resposta, "fontes": fontes, "tokens": tokens})
         return {
             "pergunta": pergunta,
             "resposta": resposta,


### PR DESCRIPTION
## Summary
- add simple dictionary-based cache with TTL to reuse answers
- avoid unnecessary OpenAI calls when the same question repeats

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1b21205e08327a52d9ab5b55ee09b