### PR TITLE
Add feedback analysis and admin dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+
+feedback.log

--- a/analyze_feedback.py
+++ b/analyze_feedback.py
@@ -1,0 +1,46 @@
+import re
+from collections import Counter
+from typing import Tuple, Counter as CounterType
+
+LOG_FILE = "feedback.log"
+
+
+def read_feedback_log() -> Tuple[int, int, CounterType[str]]:
+    """Lê o arquivo de feedback e retorna contagem de positivos, negativos e perguntas negativas."""
+    positivos = 0
+    negativos = 0
+    perguntas_negativas: CounterType[str] = Counter()
+    try:
+        with open(LOG_FILE, "r", encoding="utf-8") as f:
+            for linha in f:
+                if "Feedback positivo" in linha:
+                    positivos += 1
+                elif "Feedback negativo" in linha:
+                    negativos += 1
+                    match = re.search(r"Feedback negativo para a pergunta: (.*)", linha)
+                    if match:
+                        pergunta = match.group(1).strip()
+                        perguntas_negativas[pergunta] += 1
+    except FileNotFoundError:
+        pass
+    return positivos, negativos, perguntas_negativas
+
+
+def summarize_feedback() -> None:
+    """Imprime um resumo do feedback coletado."""
+    positivos, negativos, perguntas_negativas = read_feedback_log()
+    total = positivos + negativos
+    pct_pos = (positivos / total * 100) if total else 0
+    pct_neg = (negativos / total * 100) if total else 0
+
+    print(f"Feedbacks positivos: {positivos} ({pct_pos:.2f}%)")
+    print(f"Feedbacks negativos: {negativos} ({pct_neg:.2f}%)")
+
+    if perguntas_negativas:
+        print("\nPerguntas com mais feedbacks negativos:")
+        for pergunta, contagem in perguntas_negativas.most_common(5):
+            print(f"- {pergunta}: {contagem}")
+
+
+if __name__ == "__main__":
+    summarize_feedback()

--- a/pages/admin_dashboard.py
+++ b/pages/admin_dashboard.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import streamlit as st
+from analyze_feedback import read_feedback_log
+
+st.set_page_config(page_title="Dashboard de Feedback")
+
+st.title("Dashboard de Feedback")
+
+positivos, negativos, perguntas_negativas = read_feedback_log()
+total = positivos + negativos
+
+col1, col2 = st.columns(2)
+col1.metric("Positivos", positivos)
+col2.metric("Negativos", negativos)
+
+if total:
+    st.write(f"Porcentagem de feedbacks positivos: {positivos / total * 100:.2f}%")
+    st.write(f"Porcentagem de feedbacks negativos: {negativos / total * 100:.2f}%")
+else:
+    st.info("Nenhum feedback registrado ainda.")
+
+if perguntas_negativas:
+    st.subheader("Perguntas com mais feedbacks negativos")
+    df = pd.DataFrame(perguntas_negativas.most_common(), columns=["Pergunta", "Negativos"])
+    st.table(df)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests>=2.0.0
 presidio-analyzer>=2.2.30
 presidio-anonymizer>=2.2.30
 sentence-transformers>=2.2.2
+pandas>=1.5.0


### PR DESCRIPTION
## Summary
- add script to parse `feedback.log` and report positive/negative stats
- create Streamlit admin dashboard to visualize feedback summary
- include pandas dependency and ignore generated log file

## Testing
- `pip install pandas`
- `python analyze_feedback.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1b733b08083279a299a07bd3aa596