### PR TITLE
Add dashboard for monitoring tokens and response time

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,24 @@
 import logging
+from pathlib import Path
 from time import perf_counter, time
 from typing import Any, Dict, Tuple
 
 from fastapi import FastAPI
 from athenas.core import AthenasRAG
 
-logging.basicConfig(level=logging.INFO)
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+LOG_FILE = LOG_DIR / "backend.log"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(),
+    ],
+)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="ATHENAS MVP")

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Simple dashboard script to analyze backend logs."""
+
+import re
+from pathlib import Path
+
+LOG_FILE = Path("logs/backend.log")
+
+
+def parse_logs(log_file: Path):
+    """Parse log file for response times and tokens.
+
+    Returns a tuple (times, tokens) where times is a list of floats in seconds
+    and tokens is a list of integers.
+    """
+    times = []
+    tokens = []
+    time_pattern = re.compile(r"Tempo de resposta: ([0-9.]+)s")
+    token_pattern = re.compile(r"Tokens usados: (\d+)")
+
+    if not log_file.exists():
+        return times, tokens
+
+    with log_file.open() as fh:
+        for line in fh:
+            match_time = time_pattern.search(line)
+            if match_time:
+                times.append(float(match_time.group(1)))
+            match_tokens = token_pattern.search(line)
+            if match_tokens:
+                tokens.append(int(match_tokens.group(1)))
+    return times, tokens
+
+
+def main() -> None:
+    times, tokens = parse_logs(LOG_FILE)
+    if not times and not tokens:
+        print(f"Nenhum dado disponível em {LOG_FILE}.")
+        return
+
+    avg_time = sum(times) / len(times) if times else 0.0
+    total_tokens = sum(tokens)
+    print(f"Tempo médio de resposta: {avg_time:.2f}s")
+    print(f"Total de tokens usados: {total_tokens}")
+
+
+if __name__ == "__main__":
+    main()

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- log backend activity to a centralized `logs/backend.log`
- add `dashboard.py` to compute average response time and total tokens used from logs

## Testing
- `python dashboard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b86cd7bc832799ab4ad663cb4b4d