### PR TITLE
feat: add hybrid search with bm25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv>=1.0.0
 chromadb>=0.5.0
 langchain>=0.1.0
 langchain-community>=0.0.10
+rank-bm25>=0.2.2
 
 streamlit>=1.30.0
 requests>=2.0.0


### PR DESCRIPTION
## Summary
- index document chunks using BM25 during ingestion
- combine BM25 and Chroma searches with reciprocal rank fusion and reranking
- include rank-bm25 dependency

## Testing
- `python -m py_compile ingest.py athenas/core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b9c762d483279c3d1da365bfd3ab