### PR TITLE
feat: add simple model router

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Protótipo inicial da plataforma de **Inteligência de Acesso ao Conhecimento**.
 
 ## Estrutura do Repositório
 
-- `athenas/core.py` – pipeline básico de RAG com componentes substituíveis.
+- `athenas/core.py` – pipeline básico de RAG com componentes substituíveis e
+  roteamento simples entre modelos da OpenAI.
 - `athenas/cli.py` – interface de linha de comando de demonstração.
 - `ingest.py` – script para ingestão e anonimização de documentos no ChromaDB.
 - `backend/` – API FastAPI que expõe o pipeline de perguntas e respostas.
@@ -22,12 +23,17 @@ Crie um arquivo `.env` na raiz com as variáveis necessárias:
 ```bash
 OPENAI_API_KEY="sua-chave"
 OPENAI_CHAT_MODEL="gpt-4o-mini"
+OPENAI_FAST_MODEL="gpt-3.5-turbo"
 OPENAI_EMBEDDING_MODEL="text-embedding-ada-002"
 CROSS_ENCODER_MODEL="cross-encoder/ms-marco-MiniLM-L-6-v2"
 # opcional
 CHROMA_HOST="localhost"
 CHROMA_PORT="8001"
 ```
+
+O pipeline seleciona automaticamente entre os modelos definidos em
+`OPENAI_CHAT_MODEL` e `OPENAI_FAST_MODEL` de acordo com a complexidade da
+pergunta, equilibrando custo e desempenho.
 
 ## Instalação
 


### PR DESCRIPTION
## Summary
- route questions between OpenAI models based on complexity
- document model router usage and configuration

## Testing
- `python -m py_compile athenas/core.py && echo "py_compile success"`
- `python - <<'PY'
from athenas.core import AthenasRAG
rag = AthenasRAG()
print('complex:', rag._select_model('Explique o projeto'))
print('simple:', rag._select_model('Oi?'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b1bb3a0b808327aed325810d2a8d0f