### PR TITLE
feat: async ingestion pipeline with Celery

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 openai>=1.0.0
 sentence-transformers>=2.2.2
 redis>=5.0.0
+celery[redis]>=5.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - redis
     environment:
       REDIS_URL: redis://redis:6379/0
+  worker:
+    build:
+      context: .
+      dockerfile: worker.Dockerfile
+    depends_on:
+      - vector-db
+      - redis
+    environment:
+      REDIS_URL: redis://redis:6379/0
   vector-db:
     image: chromadb/chroma
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ presidio-analyzer>=2.2.30
 presidio-anonymizer>=2.2.30
 sentence-transformers>=2.2.2
 pandas>=1.5.0
+celery[redis]>=5.3.0

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["celery", "-A", "worker.celery_app", "worker", "--loglevel=info"]
+

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,19 @@
+"""Tarefas assíncronas para processamento de documentos."""
+
+import os
+
+from celery import Celery
+
+from ingest import ingest_file
+
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+celery_app = Celery("athenas", broker=REDIS_URL, backend=REDIS_URL)
+
+
+@celery_app.task
+def process_document(file_path: str) -> None:
+    """Executa a ingestão de um documento no background."""
+    ingest_file(file_path)
+


### PR DESCRIPTION
## Summary
- add endpoint to upload documents and enqueue ingestion tasks
- introduce Celery worker and Docker configuration for background processing
- refactor ingestion script to support single-file ingestion

## Testing
- `python -m py_compile Projeto_ATHENAS/backend/main.py Projeto_ATHENAS/ingest.py Projeto_ATHENAS/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1be75d1c88327917ecaac2d7f6f0b