### PR TITLE
Add conversational memory with question rewriting

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,14 @@ if st.button("Enviar"):
     if pergunta:
         try:
             with st.spinner("ATHENAS está pensando..."):
-                resp = requests.get("http://localhost:8000/answer", params={"pergunta": pergunta})
+                historico = st.session_state["historico"][-5:]
+                resp = requests.get(
+                    "http://localhost:8000/answer",
+                    params={
+                        "pergunta": pergunta,
+                        "historico": json.dumps(historico, ensure_ascii=False),
+                    },
+                )
             if resp.ok:
                 data = resp.json()
                 resposta = data.get("resposta", "")


### PR DESCRIPTION
## Summary
- Send recent chat history from Streamlit app to backend for contextual questions
- Cache and forward conversation history in backend answer endpoint
- Add LLM-based question rewriter in core to condense history into standalone query

## Testing
- `python -m py_compile backend/main.py app.py athenas/core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1c0ecf008832782e5c4f6573d518e