### PR TITLE
Implement metadata-based access control for documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ Uma API de demonstração pode ser levantada com Docker:
 docker-compose up --build
 ```
 
-Após a inicialização o endpoint estará disponível em `http://localhost:8000/answer`. Exemplo:
+Após a inicialização o endpoint estará disponível em `http://localhost:8000/answer`. 
+O parâmetro opcional `grupos` permite informar as permissões do usuário. Exemplo:
 
 ```
-http://localhost:8000/answer?pergunta=Qual%20o%20objetivo%20do%20projeto?
+http://localhost:8000/answer?pergunta=Qual%20o%20objetivo%20do%20projeto?&grupos=vendas,diretoria
 ```
 
 O serviço `vector-db` expõe a porta `8001` apenas para fins de demonstração.


### PR DESCRIPTION
## Summary
- add allowed_groups metadata during document ingestion
- filter retriever and BM25 results by user groups
- expose `grupos` parameter on `/answer` endpoint to enforce permissions

## Testing
- `python -m py_compile ingest.py backend/main.py athenas/core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c29c03188327ba462c44c49c2055