### PR TITLE
feat: add presentation generator

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,3 +72,31 @@ if st.button("Enviar"):
             )
     else:
         st.warning("Digite uma pergunta antes de enviar.")
+
+
+st.header("Gerar apresentação")
+topico = st.text_input("Tópico da apresentação", key="topico_apresentacao")
+num_slides = st.number_input(
+    "Número de slides", min_value=1, max_value=20, value=5, key="num_slides_apresentacao"
+)
+
+if st.button("Gerar apresentação"):
+    if topico:
+        try:
+            with st.spinner("Gerando apresentação..."):
+                resp = requests.get(
+                    "http://localhost:8000/gerar_apresentacao",
+                    params={"topico": topico, "num_slides": int(num_slides)},
+                )
+            if resp.ok:
+                data = resp.json()
+                slides = data.get("slides", [])
+                for i, slide in enumerate(slides, 1):
+                    st.markdown(f"**Slide {i}:** {slide}")
+            else:
+                st.error("Desculpe, não foi possível gerar a apresentação.")
+        except Exception as e:
+            logging.error("Erro ao gerar apresentação: %s", e)
+            st.error("Não consegui conectar ao serviço de geração.")
+    else:
+        st.warning("Digite um tópico antes de gerar.")

--- a/backend/main.py
+++ b/backend/main.py
@@ -79,6 +79,30 @@ async def answer(
         raise
 
 
+@app.get("/gerar_apresentacao")
+async def gerar_apresentacao(topico: str, num_slides: int = 5):
+    """Gera uma apresentação simples baseada em um tópico."""
+    start_time = perf_counter()
+    logger.info("Solicitação de apresentação: %s", topico)
+    try:
+        rag = AthenasRAG()
+        slides, tokens = rag.generate_presentation(topico, num_slides)
+        elapsed = perf_counter() - start_time
+        logger.info("Tempo de geração: %.2fs", elapsed)
+        logger.info("Tokens usados: %s", tokens)
+        return {
+            "topico": topico,
+            "slides": slides,
+            "tokens": tokens,
+            "tempo_resposta": elapsed,
+        }
+    except Exception as exc:
+        elapsed = perf_counter() - start_time
+        logger.exception("Erro ao gerar apresentação: %s", exc)
+        logger.info("Tempo até erro: %.2fs", elapsed)
+        raise
+
+
 @app.post("/documentos")
 async def upload_documento(file: UploadFile = File(...)):
     """Recebe um arquivo e agenda a ingestão assíncrona."""


### PR DESCRIPTION
## Summary
- add presentation generator and expose via AthenasRAG
- support presentation generation via new backend endpoint
- add Streamlit UI to request slide outlines

## Testing
- `python -m py_compile athenas/core.py backend/main.py app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1c41bd4208327aa1d33ba329fd8f2