### PR TITLE
feat: add intent router and basic tools

### DIFF
--- a/athenas/cli.py
+++ b/athenas/cli.py
@@ -16,13 +16,9 @@ def main() -> None:
     args = parser.parse_args()
 
     rag = AthenasRAG()
-    resposta, fontes, tokens = rag.answer(args.pergunta)
-    print({
-        "pergunta": args.pergunta,
-        "resposta": resposta,
-        "fontes": fontes,
-        "tokens": tokens,
-    })
+    resultado = rag.executar(args.pergunta)
+    resultado["pergunta"] = args.pergunta
+    print(resultado)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- introduce LLM-based router to select appropriate tool
- add tools for document search, executive summary generation, and feedback analysis
- update CLI to execute through the router

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5aff480388327baee113da6e87c8a