### PR TITLE
Sanitize metadata before storing in ChromaDB and update docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ O script divide os documentos em *chunks*, anonimiza informações sensíveis co
 Uma API de demonstração pode ser levantada com Docker:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 Após a inicialização o endpoint estará disponível em `http://localhost:8000/answer`. 

--- a/ingest.py
+++ b/ingest.py
@@ -80,16 +80,18 @@ def ingest_file(
     documents = _load_file(path)
     for doc in documents:
         sanitized = _anonymize(doc.page_content)
+        metadata = {"source": path.name, "allowed_groups": allowed_groups}
+        sanitized_metadata = {k: str(v) for k, v in metadata.items()}
         for i, chunk in enumerate(splitter.split_text(sanitized)):
             embedding = rag.embedder(chunk)
             collection.add(
                 ids=[f"{path.stem}-{i}-{uuid.uuid4()}"],
                 documents=[chunk],
-                metadatas=[{"source": path.name, "allowed_groups": allowed_groups}],
+                metadatas=[sanitized_metadata],
                 embeddings=[embedding],
             )
             bm25_docs.append(chunk)
-            bm25_metas.append({"source": path.name, "allowed_groups": allowed_groups})
+            bm25_metas.append(metadata)
             bm25_corpus.append(chunk.split())
 
     if os.path.exists("bm25_index.pkl"):


### PR DESCRIPTION
## Summary
- Convert metadata values to strings before adding documents to ChromaDB
- Clarify Docker usage with `docker compose` in README

## Testing
- `python -m py_compile ingest.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba35d7964083279282fe0701d32658